### PR TITLE
Make Registry and AbstractFactory thread-safe

### DIFF
--- a/docs/docs/user/abstract_factory.md
+++ b/docs/docs/user/abstract_factory.md
@@ -525,6 +525,31 @@ Keep in mind that each class has to be loaded at least once to be registered.
 The error `AbstractClassAbstractFactoryError` will be raised if you try to instantiate an abstract
 class because an abstract class cannot be instantiated.
 
+## Thread safety
+
+Classes that use the `AbstractFactory` metaclass can safely be registered and instantiated
+from multiple threads. All the mutating operations (`register_object`, `unregister`, and the
+implicit registration done by `factory`) are synchronized with an internal lock shared by the
+base factory class and all its child classes.
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+from objectory import AbstractFactory
+
+
+class BaseClass(metaclass=AbstractFactory):
+    pass
+
+
+def create_child_class(i: int) -> type:
+    return type(f"ChildClass{i}", (BaseClass,), {})
+
+
+with ThreadPoolExecutor(max_workers=8) as executor:
+    child_classes = list(executor.map(create_child_class, range(100)))
+```
+
 ## Limitations
 
 The  `AbstractFactory` metaclass adds some attributes and methods to the classes.

--- a/docs/docs/user/registry.md
+++ b/docs/docs/user/registry.md
@@ -172,8 +172,9 @@ class MyBear:
 
 :warning: Accessing an unknown attribute (e.g. `registry.other`) is not a read-only
 operation: it implicitly creates and stores a new sub-registry under that name, even for a
-typo or a plain `hasattr` check. If you want to create a sub-registry without relying on this
-side effect, use `get_or_create` instead:
+typo or a plain `hasattr` check. This behavior is deprecated and emits a `FutureWarning`;
+it will raise an `AttributeError` instead in a future release. If you want to create a
+sub-registry without relying on this side effect, use `get_or_create` instead:
 
 ```python
 from objectory import Registry
@@ -574,4 +575,28 @@ from objectory import Registry
 
 registry = Registry()
 registry.clear_filters(nested=True)
+```
+
+## Thread safety
+
+A `Registry` instance can safely be shared and mutated from multiple threads.
+All the mutating operations (`register_object`, `unregister`, `clear`, `clear_filters`,
+`set_class_filter`, `get_or_create`, and the implicit registration done by `factory`) are
+synchronized with an internal lock, so concurrent calls will not corrupt the internal state.
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+from objectory import Registry
+
+registry = Registry()
+
+
+class ClassToRegister:
+    pass
+
+
+with ThreadPoolExecutor(max_workers=8) as executor:
+    for _ in range(100):
+        executor.submit(registry.register_object, ClassToRegister)
 ```

--- a/src/objectory/abstract_factory.py
+++ b/src/objectory/abstract_factory.py
@@ -11,6 +11,7 @@ __all__ = ["AbstractFactory", "is_abstract_factory", "register", "register_child
 
 import inspect
 import logging
+import threading
 from abc import ABCMeta
 from typing import TYPE_CHECKING, Any
 
@@ -56,6 +57,12 @@ class AbstractFactory(ABCMeta):
             class body. This becomes the ``__dict__`` attribute of the
             class.
 
+    Note:
+        Mutating operations (e.g. ``register_object``, ``unregister``)
+        are synchronized with an internal lock shared by a factory
+        hierarchy, so classes using this metaclass can safely be
+        registered from multiple threads.
+
     Example:
         ```pycon
         >>> from objectory import AbstractFactory
@@ -75,6 +82,7 @@ class AbstractFactory(ABCMeta):
     def __init__(cls, name: str, bases: tuple[type, ...], dct: dict[str, Any]) -> None:
         if not hasattr(cls, "_abstractfactory_inheritors"):
             cls._abstractfactory_inheritors = {}
+            cls._abstractfactory_lock = threading.RLock()
         cls.register_object(cls)
         super().__init__(name, bases, dct)
 
@@ -190,13 +198,16 @@ class AbstractFactory(ABCMeta):
         """
         cls._abstractfactory_check_object(obj)
         name = get_fully_qualified_name(obj)
-        if (
-            cls._abstractfactory_is_name_registered(name)
-            and cls._abstractfactory_inheritors[name] != obj
-        ):
-            logger.warning(f"The class {name} already exists. The new class replaces the old one")
+        with cls._abstractfactory_lock:
+            if (
+                cls._abstractfactory_is_name_registered(name)
+                and cls._abstractfactory_inheritors[name] != obj
+            ):
+                logger.warning(
+                    f"The class {name} already exists. The new class replaces the old one"
+                )
 
-        cls._abstractfactory_inheritors[name] = obj
+            cls._abstractfactory_inheritors[name] = obj
 
     def unregister(cls, name: str) -> None:
         r"""Remove a registered object from the factory.
@@ -230,13 +241,15 @@ class AbstractFactory(ABCMeta):
 
             ```
         """
-        resolved_name = cls._abstractfactory_resolve_name(name)
-        if resolved_name is None or not cls._abstractfactory_is_name_registered(resolved_name):
-            msg = (
-                f"It is not possible to remove an object which is not registered (received: {name})"
-            )
-            raise UnregisteredObjectFactoryError(msg)
-        cls._abstractfactory_inheritors.pop(resolved_name)
+        with cls._abstractfactory_lock:
+            resolved_name = cls._abstractfactory_resolve_name(name)
+            if resolved_name is None or not cls._abstractfactory_is_name_registered(resolved_name):
+                msg = (
+                    "It is not possible to remove an object which is not registered "
+                    f"(received: {name})"
+                )
+                raise UnregisteredObjectFactoryError(msg)
+            cls._abstractfactory_inheritors.pop(resolved_name)
 
     def _abstractfactory_get_target_from_name(cls, name: str) -> type | Callable:
         """Get the class or function to use given its name.
@@ -251,17 +264,18 @@ class AbstractFactory(ABCMeta):
             UnregisteredObjectFactoryError: if it is not possible
                 to find the target.
         """
-        resolved_name = cls._abstractfactory_resolve_name(name)
-        if resolved_name is None:
-            msg = (
-                f"Unable to create the object `{name}` because it is not registered. "
-                f"Registered objects of {cls.__qualname__} "
-                f"are {set(cls._abstractfactory_inheritors.keys())}"
-            )
-            raise UnregisteredObjectFactoryError(msg)
-        if not cls._abstractfactory_is_name_registered(resolved_name):
-            cls.register_object(import_object(resolved_name))
-        return cls._abstractfactory_inheritors[resolved_name]
+        with cls._abstractfactory_lock:
+            resolved_name = cls._abstractfactory_resolve_name(name)
+            if resolved_name is None:
+                msg = (
+                    f"Unable to create the object `{name}` because it is not registered. "
+                    f"Registered objects of {cls.__qualname__} "
+                    f"are {set(cls._abstractfactory_inheritors.keys())}"
+                )
+                raise UnregisteredObjectFactoryError(msg)
+            if not cls._abstractfactory_is_name_registered(resolved_name):
+                cls.register_object(import_object(resolved_name))
+            return cls._abstractfactory_inheritors[resolved_name]
 
     def _abstractfactory_resolve_name(cls, name: str) -> str | None:
         r"""Try to resolve the name.

--- a/src/objectory/registry.py
+++ b/src/objectory/registry.py
@@ -6,6 +6,8 @@ __all__ = ["Registry"]
 
 import inspect
 import logging
+import threading
+import warnings
 from collections.abc import Callable
 from typing import Any, TypeVar
 
@@ -51,9 +53,16 @@ class Registry:
         Accessing an unknown attribute (e.g. ``registry.other``) is not a
         read-only operation by default: it implicitly creates and stores a
         new sub-registry under that name, even for a typo or a mere
-        ``hasattr`` check. Use :meth:`get_or_create` to make this creation
+        ``hasattr`` check. This behavior is deprecated and emits a
+        ``FutureWarning``. Use :meth:`get_or_create` to make this creation
         explicit, or pass ``strict=True`` to disable auto-creation and
-        raise ``AttributeError`` for unknown attributes instead.
+        raise ``AttributeError`` for unknown attributes instead (this will
+        become the default behavior in a future release).
+
+    Note:
+        Mutating operations (e.g. ``register_object``, ``unregister``,
+        ``clear``) are synchronized with an internal lock, so a single
+        ``Registry`` instance can safely be shared across threads.
     """
 
     _CLASS_FILTER = "class_filter"
@@ -62,6 +71,7 @@ class Registry:
         self._state = {}
         self._filters = {}
         self._strict = strict
+        self._lock = threading.RLock()
 
     def __getattr__(self, key: str) -> Registry | type:
         r"""Get the registry associated to a key.
@@ -86,14 +96,24 @@ class Registry:
 
             ```
         """
-        if key not in self._state and self._strict:
-            msg = (
-                f"'{type(self).__qualname__}' object has no attribute '{key}'. "
-                "This registry was created with `strict=True` so unknown attributes "
-                "are not auto-created; use `get_or_create` to create a sub-registry "
-                "explicitly."
+        if key not in self._state:
+            if self._strict:
+                msg = (
+                    f"'{type(self).__qualname__}' object has no attribute '{key}'. "
+                    "This registry was created with `strict=True` so unknown attributes "
+                    "are not auto-created; use `get_or_create` to create a sub-registry "
+                    "explicitly."
+                )
+                raise AttributeError(msg)
+            warnings.warn(
+                f"Accessing the unknown attribute '{key}' implicitly creates a new "
+                "sub-registry. This is deprecated and will raise an `AttributeError` "
+                "in a future release. Use `get_or_create` to create a sub-registry "
+                "explicitly, or pass `strict=True` to the registry constructor to "
+                "opt into the future behavior now.",
+                FutureWarning,
+                stacklevel=2,
             )
-            raise AttributeError(msg)
         return self.get_or_create(key)
 
     def get_or_create(self, key: str) -> Registry:
@@ -121,10 +141,11 @@ class Registry:
 
             ```
         """
-        if key not in self._state:
-            self._state[key] = Registry(strict=self._strict)
-        if self._is_registry(key):
-            return self._state[key]
+        with self._lock:
+            if key not in self._state:
+                self._state[key] = Registry(strict=self._strict)
+            if self._is_registry(key):
+                return self._state[key]
         msg = (
             f"The attribute `{key}` is not a registry. You can use this function only to access "
             "a Registry object."
@@ -173,11 +194,12 @@ class Registry:
 
             ```
         """
-        if nested:  # If True, clear all the sub-registries.
-            for value in self._state.values():
-                if isinstance(value, Registry):
-                    value.clear(nested)
-        self._state.clear()
+        with self._lock:
+            if nested:  # If True, clear all the sub-registries.
+                for value in self._state.values():
+                    if isinstance(value, Registry):
+                        value.clear(nested)
+            self._state.clear()
 
     def clear_filters(self, nested: bool = False) -> None:
         r"""Clear all the filters of the registry.
@@ -200,11 +222,12 @@ class Registry:
 
             ```
         """
-        if nested:  # If True, clear all the sub-registries.
-            for value in self._state.values():
-                if isinstance(value, Registry):
-                    value.clear_filters(nested)
-        self._filters.clear()
+        with self._lock:
+            if nested:  # If True, clear all the sub-registries.
+                for value in self._state.values():
+                    if isinstance(value, Registry):
+                        value.clear_filters(nested)
+            self._filters.clear()
 
     def factory(self, _target_: str, *args: Any, _init_: str = "__init__", **kwargs: Any) -> Any:
         r"""Instantiate dynamically an object given its configuration.
@@ -365,16 +388,17 @@ class Registry:
             msg = f"The name has to be a string (received: {name})"
             raise TypeError(msg)
 
-        if name in self._state:
-            if self._is_registry(name):
-                msg = f"The name `{name}` is already used by a sub-registry"
-                raise InvalidNameFactoryError(msg)
-            if self._state[name] != obj:
-                logger.warning(
-                    f"The name `{name}` already exists and its value will be replaced by {obj}"
-                )
+        with self._lock:
+            if name in self._state:
+                if self._is_registry(name):
+                    msg = f"The name `{name}` is already used by a sub-registry"
+                    raise InvalidNameFactoryError(msg)
+                if self._state[name] != obj:
+                    logger.warning(
+                        f"The name `{name}` already exists and its value will be replaced by {obj}"
+                    )
 
-        self._state[name] = obj
+            self._state[name] = obj
 
     def registered_names(self, include_registry: bool = True) -> set[str]:
         r"""Get the names of all the registered objects.
@@ -433,13 +457,15 @@ class Registry:
 
             ```
         """
-        resolved_name = self._resolve_name(name)
-        if resolved_name is None or not self._is_name_registered(resolved_name):
-            msg = (
-                f"It is not possible to remove an object which is not registered (received: {name})"
-            )
-            raise UnregisteredObjectFactoryError(msg)
-        self._state.pop(resolved_name)
+        with self._lock:
+            resolved_name = self._resolve_name(name)
+            if resolved_name is None or not self._is_name_registered(resolved_name):
+                msg = (
+                    "It is not possible to remove an object which is not registered "
+                    f"(received: {name})"
+                )
+                raise UnregisteredObjectFactoryError(msg)
+            self._state.pop(resolved_name)
 
     def set_class_filter(self, cls: type | None) -> None:
         r"""Set the class filter so only the child classes of this class
@@ -470,14 +496,15 @@ class Registry:
 
             ```
         """
-        if cls is None:
-            self._filters.pop(self._CLASS_FILTER, None)
-            return
+        with self._lock:
+            if cls is None:
+                self._filters.pop(self._CLASS_FILTER, None)
+                return
 
-        if not inspect.isclass(cls):
-            msg = f"The class filter has to be a class (received: {cls})"
-            raise TypeError(msg)
-        self._filters[self._CLASS_FILTER] = cls
+            if not inspect.isclass(cls):
+                msg = f"The class filter has to be a class (received: {cls})"
+                raise TypeError(msg)
+            self._filters[self._CLASS_FILTER] = cls
 
     def _check_object(self, obj: type | Callable) -> None:
         r"""Check if the object is valid for this registry before
@@ -519,17 +546,18 @@ class Registry:
             UnregisteredObjectFactoryError: if it is not possible
                 to find the target.
         """
-        resolved_name = self._resolve_name(name)
-        if resolved_name is None:
-            msg = (
-                f"Unable to create the object `{name}` because it is not registered. "
-                f"Registered objects of {type(self).__qualname__} are "
-                f"{self.registered_names(include_registry=False)}."
-            )
-            raise UnregisteredObjectFactoryError(msg)
-        if not self._is_name_registered(resolved_name):
-            self.register_object(import_object(resolved_name))
-        return self._state[resolved_name]
+        with self._lock:
+            resolved_name = self._resolve_name(name)
+            if resolved_name is None:
+                msg = (
+                    f"Unable to create the object `{name}` because it is not registered. "
+                    f"Registered objects of {type(self).__qualname__} are "
+                    f"{self.registered_names(include_registry=False)}."
+                )
+                raise UnregisteredObjectFactoryError(msg)
+            if not self._is_name_registered(resolved_name):
+                self.register_object(import_object(resolved_name))
+            return self._state[resolved_name]
 
     def _is_name_registered(self, name: str) -> bool:
         r"""Indicate if the name exists or not in the registry.

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from objectory import AbstractFactory, Registry
+
+##############################################
+#     Integration tests for thread safety     #
+##############################################
+
+
+def test_registry_concurrent_register_and_factory() -> None:
+    r"""Register objects and instantiate them concurrently through the
+    public API, mixing writers and readers on the same registry."""
+    registry = Registry()
+    n_classes = 200
+
+    classes = [type(f"IntegrationClass{i}", (), {}) for i in range(n_classes)]
+    for cls in classes:
+        registry.register_object(cls, name=cls.__name__)
+
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def register_more(i: int) -> None:
+        try:
+            cls = type(f"IntegrationExtraClass{i}", (), {})
+            registry.register_object(cls, name=cls.__name__)
+        except Exception as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+
+    def instantiate(i: int) -> None:
+        try:
+            cls = classes[i % n_classes]
+            obj = registry.factory(cls.__name__)
+            assert isinstance(obj, cls)
+        except Exception as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        futures = [executor.submit(register_more, i) for i in range(100)]
+        futures += [executor.submit(instantiate, i) for i in range(200)]
+        for future in futures:
+            future.result()
+
+    assert not errors
+    assert len(registry) == n_classes + 100
+
+
+def test_registry_concurrent_get_or_create_sub_registries() -> None:
+    r"""Concurrently create the same sub-registries from multiple
+    threads and check that a single sub-registry instance is created
+    per key."""
+    registry = Registry()
+    n_keys = 20
+    n_workers_per_key = 25
+
+    def create_sub_registry(key: str) -> Registry:
+        return registry.get_or_create(key)
+
+    with ThreadPoolExecutor(max_workers=64) as executor:
+        futures = {
+            key: [executor.submit(create_sub_registry, key) for _ in range(n_workers_per_key)]
+            for key in (f"key{i}" for i in range(n_keys))
+        }
+        results = {key: [f.result() for f in fs] for key, fs in futures.items()}
+
+    for key, sub_registries in results.items():
+        assert all(sub_registry is sub_registries[0] for sub_registry in sub_registries)
+        assert registry.get_or_create(key) is sub_registries[0]
+    assert len(registry) == n_keys
+
+
+def test_abstract_factory_concurrent_subclassing_and_factory() -> None:
+    r"""Create subclasses of an ``AbstractFactory`` base class from
+    multiple threads and instantiate them concurrently through the
+    public API."""
+
+    class IntegrationBaseClass(metaclass=AbstractFactory):
+        pass
+
+    n_subclasses = 100
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+    created: list[type] = []
+
+    def create_subclass(i: int) -> None:
+        try:
+            new_cls = type(
+                f"IntegrationSubClass{i}",
+                (IntegrationBaseClass,),
+                {},
+            )
+            with lock:
+                created.append(new_cls)
+        except Exception as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        futures = [executor.submit(create_subclass, i) for i in range(n_subclasses)]
+        for future in futures:
+            future.result()
+
+    assert not errors
+    assert len(created) == n_subclasses
+
+    def instantiate(cls: type) -> None:
+        try:
+            obj = IntegrationBaseClass.factory(cls.__qualname__)
+            assert isinstance(obj, cls)
+        except Exception as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        futures = [executor.submit(instantiate, cls) for cls in created]
+        for future in futures:
+            future.result()
+
+    assert not errors
+    # +1 for IntegrationBaseClass itself, which is auto-registered.
+    assert len(IntegrationBaseClass.inheritors) == n_subclasses + 1

--- a/tests/unit/test_abstract_factory.py
+++ b/tests/unit/test_abstract_factory.py
@@ -545,3 +545,38 @@ def test_is_abstract_factory_false() -> None:
 
 def test_is_abstract_factory_false_function() -> None:
     assert not is_abstract_factory(function_to_register)
+
+
+##########################################
+#     Tests for thread safety           #
+##########################################
+
+
+def test_register_object_thread_safety() -> None:
+    import threading
+
+    class BaseClassForThreadSafety(metaclass=AbstractFactory):
+        pass
+
+    n_threads = 16
+    n_objects_per_thread = 25
+
+    def make_class(i: int) -> type:
+        return type(f"GeneratedThreadSafeClass{i}", (), {})
+
+    classes = [make_class(i) for i in range(n_threads * n_objects_per_thread)]
+
+    def worker(start: int) -> None:
+        for cls in classes[start : start + n_objects_per_thread]:
+            BaseClassForThreadSafety.register_object(cls)
+
+    threads = [
+        threading.Thread(target=worker, args=(i * n_objects_per_thread,)) for i in range(n_threads)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    # +1 for BaseClassForThreadSafety itself, which is auto-registered.
+    assert len(BaseClassForThreadSafety.inheritors) == n_threads * n_objects_per_thread + 1

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import TYPE_CHECKING, TypeVar
@@ -324,8 +325,17 @@ def test_getattr_strict_propagates_to_sub_registries() -> None:
 def test_getattr_non_strict_creates_sub_registry() -> None:
     registry = Registry()
     assert "other" not in registry._state
-    registry.other  # noqa: B018
+    with pytest.warns(FutureWarning, match=r"implicitly creates a new sub-registry"):
+        registry.other  # noqa: B018
     assert "other" in registry._state
+
+
+def test_getattr_non_strict_known_attribute_no_warning() -> None:
+    registry = Registry()
+    registry.get_or_create("other")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        registry.other  # noqa: B018
 
 
 def test_register_child_classes_ignore_abstract_foo() -> None:
@@ -685,6 +695,33 @@ def test_registry_len_2() -> None:
     registry.register_object(ClassToRegister)
     registry.other.register_object(ClassToRegister)
     assert len(registry) == 2
+
+
+def test_registry_register_object_thread_safety() -> None:
+    import threading
+
+    registry = Registry()
+    n_threads = 16
+    n_objects_per_thread = 25
+
+    def make_class(i: int) -> type:
+        return type(f"GeneratedClass{i}", (), {})
+
+    classes = [make_class(i) for i in range(n_threads * n_objects_per_thread)]
+
+    def worker(start: int) -> None:
+        for cls in classes[start : start + n_objects_per_thread]:
+            registry.register_object(cls, name=cls.__name__)
+
+    threads = [
+        threading.Thread(target=worker, args=(i * n_objects_per_thread,)) for i in range(n_threads)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(registry) == n_threads * n_objects_per_thread
 
 
 def test_registered_names() -> None:


### PR DESCRIPTION
## Summary
- Guards all mutating operations on `Registry` (`register_object`, `unregister`, `clear`, `clear_filters`, `set_class_filter`, `get_or_create`, and the lazy import-then-register path in `factory()`) with an internal `threading.RLock`, so a single instance can safely be shared across threads.
- Guards the equivalent operations on `AbstractFactory` with a lock shared across a factory's whole class hierarchy (base class + all children), since they share the same `inheritors` dict.
- Deprecates `Registry`'s implicit sub-registry auto-creation on unknown attribute access (e.g. `registry.other` for a typo or `hasattr` check): now emits a `FutureWarning` and will raise `AttributeError` in a future release. `get_or_create()` or `strict=True` remain the explicit alternatives.
- Updates the `Registry` and `AbstractFactory` user docs with "Thread safety" sections and runnable examples, and clarifies the auto-vivification warning behavior.

## Test plan
- [x] Unit tests: concurrent registration on both `Registry` and `AbstractFactory` (`tests/unit/test_registry.py`, `tests/unit/test_abstract_factory.py`).
- [x] Integration tests exercising the public API concurrently — register/factory, `get_or_create` racing on the same key, and concurrent subclassing + instantiation (`tests/integration/test_thread_safety.py`).
- [x] `pytest --xdoctest --cov=objectory` — 310 passed, 100% coverage.
- [x] `ruff check` / `ruff format --check` clean.